### PR TITLE
Add options for MediaWiki output beautifying

### DIFF
--- a/t/05_05_mediawiki_custom_tags.t
+++ b/t/05_05_mediawiki_custom_tags.t
@@ -1,0 +1,82 @@
+#!/usr/bin/perl -w
+
+###############################################################################
+#
+# A test for Pod::Simple::Wiki.
+#
+# Tests for custom formatting codes.
+#
+# reverse('©'), October 2012, Peter Hallam, pragmatic@cpan.org
+#
+
+
+use strict;
+
+use Pod::Simple::Wiki;
+use Test::More tests => 1;
+
+my $style = 'mediawiki';
+my $opts  = {
+    custom_tags => {
+        '<pre>'     => "<syntaxhighlight lang=\"perl\">\n",
+        '</pre>'    => "\n</syntaxhighlight>\n\n",
+    }
+};
+
+# Output the tests for visual testing in the wiki.
+# END{output_tests()};
+
+my @tests  = (
+  # Simple formatting tests
+  [ "=pod\n\n Foo"      => qq(<syntaxhighlight lang=\"perl\">\n Foo\n</syntaxhighlight>\n\n),  'Syntaxhighlight code'  ],
+
+
+);
+
+
+
+###############################################################################
+#
+#  Run the tests.
+#
+for my $test_ref (@tests) {
+
+    my $parser  = Pod::Simple::Wiki->new($style, $opts);
+    my $pod     = $test_ref->[0];
+    my $target  = $test_ref->[1];
+    my $name    = $test_ref->[2];
+    my $wiki;
+
+    $parser->output_string(\$wiki);
+    $parser->parse_string_document($pod);
+
+    is($wiki, $target, "\tTesting: $name");
+}
+
+
+###############################################################################
+#
+# Output the tests for visual testing in the wiki.
+#
+sub output_tests {
+
+    my $test = 1;
+
+    print "\n\n";
+
+    for my $test_ref (@tests) {
+
+        my $parser  =  Pod::Simple::Wiki->new($style, $opts);
+        my $pod     =  $test_ref->[0];
+        my $name    =  $test_ref->[2];
+
+        $pod        =~ s/=pod\n\n//;
+        $pod        = "=pod\n\n=head2 Test ". $test++ . " $name\n\n$pod";
+
+        $parser->parse_string_document($pod);
+    }
+}
+
+
+__END__
+

--- a/t/05_06_mediawiki_transformer_lists.t
+++ b/t/05_06_mediawiki_transformer_lists.t
@@ -1,0 +1,168 @@
+#!/usr/bin/perl -w
+
+###############################################################################
+#
+# A test for Pod::Simple::Wiki.
+#
+# Tests for =over ... =back regions.
+#
+# reverse('©'), October 2012, Peter Hallam, pragmatic@cpan.org
+#
+
+
+use strict;
+
+use Pod::Simple::Wiki;
+use Test::More tests => 1;
+
+my $style = 'mediawiki';
+my $opts  = { transformer_lists => 1 };
+
+# Output the tests for visual testing in the wiki.
+# END{output_tests()};
+
+my @tests;
+
+#
+# Extract tests embedded in _DATA_ section.
+#
+my $test_no = 1;
+my $pod;
+my $test = '';
+my $todo = '';;
+my $name;
+
+while (<DATA>) {
+    if (/^#/) {
+        $name = $1 if /NAME: (.*)/;
+        $todo = $1 if /TODO: (.*)/;
+
+        if ($test) {
+            if ($test_no % 2) {
+                $pod = $test;
+            }
+            else {
+                push @tests, [$pod, $test, $name, $todo];
+                $name = '';
+                $todo = '';
+            }
+
+            $test = '';
+            $test_no++;
+        }
+        next;
+    }
+    s/\r//;     # Remove any \r chars that slip in.
+    s/\\t/\t/g; # Sub back in any escaped tabs.
+    s/\\#/#/g;  # Sub back in any escaped comments.
+    $test .= $_;
+}
+
+
+###############################################################################
+#
+#  Run the tests.
+#
+for my $test_ref (@tests) {
+
+    my $parser  = Pod::Simple::Wiki->new($style, $opts);
+    my $pod     = $test_ref->[0];
+    my $target  = $test_ref->[1];
+    my $name    = $test_ref->[2];
+    my $todo    = $test_ref->[3];
+    my $wiki;
+
+    $parser->output_string(\$wiki);
+    $parser->parse_string_document($pod);
+
+    local $TODO = $todo;
+    is($wiki, $target, " \t" . $name);
+}
+
+
+###############################################################################
+#
+# Output the tests for visual testing in the wiki.
+#
+sub output_tests {
+
+    my $test = 1;
+
+    print "\n----\n\n";
+
+    for my $test_ref (@tests) {
+
+        my $parser  =  Pod::Simple::Wiki->new($style, $opts);
+        my $pod     =  $test_ref->[0];
+        my $name    =  $test_ref->[2];
+
+        print "Test ", $test++, ":\t", $name, "\n";
+        $parser->parse_string_document($pod);
+        print "\n----\n\n";
+    }
+}
+
+__DATA__
+################################################################################
+#
+# Test data.
+#
+################################################################################
+#
+# NAME: Test for varied nested list (incorrect).
+#
+# Note that the output is not formatted correctly (see the next TODO test)
+#
+=pod
+
+=over
+
+=item *
+
+Bullet item 1.0
+
+=over
+
+=item 1
+
+Number item 1.1
+
+=over
+
+=item Foo
+
+Definition item 1.2
+
+=item Bar
+
+Definition item 2.2
+
+=back
+
+=item 2
+
+Number item 2.1
+
+=back
+
+=item *
+
+Bullet item 2.0
+
+=back
+
+=cut
+#
+#
+# Expected output.
+#
+#
+* Bullet item 1.0
+\## Number item 1.1::; Foo<p>Definition item 1.2::; Bar<p>Definition item 2.2## Number item 2.1
+* Bullet item 2.0
+
+###############################################################################
+#
+# End
+#
+###############################################################################

--- a/t/05_07_mediawiki_link_prefix.t
+++ b/t/05_07_mediawiki_link_prefix.t
@@ -1,0 +1,79 @@
+#!/usr/bin/perl -w
+
+###############################################################################
+#
+# A test for Pod::Simple::Wiki.
+#
+# Tests for the CPANification of L<> links.
+#
+# reverse('©'), October 2012, Peter Hallam, pragmatic@cpan.org
+#
+
+
+use strict;
+
+use Pod::Simple::Wiki;
+use Test::More tests => 2;
+
+my $style = 'mediawiki';
+my $opts  = { link_prefix => 'http://search.cpan.org/perldoc?' };
+
+# Output the tests for visual testing in the wiki.
+# END{output_tests()};
+
+my @tests  = (
+
+  # Links
+  [ qq(=pod\n\nL<Other::Module>) => qq([http://search.cpan.org/perldoc?Other::Module Other::Module]\n\n),   'Other::Module'],
+  [ qq(=pod\n\nL<Other::Module/"METHODS">)
+    => qq([http://search.cpan.org/perldoc?Other::Module#METHODS "METHODS" in Other::Module]\n\n),
+    'Other::Module/METHODS'],
+
+);
+
+
+
+###############################################################################
+#
+#  Run the tests.
+#
+for my $test_ref (@tests) {
+
+    my $parser  = Pod::Simple::Wiki->new($style, $opts);
+    my $pod     = $test_ref->[0];
+    my $target  = $test_ref->[1];
+    my $name    = $test_ref->[2];
+    my $wiki;
+
+    $parser->output_string(\$wiki);
+    $parser->parse_string_document($pod);
+
+    is($wiki, $target, "\tTesting: $name");
+}
+
+
+###############################################################################
+#
+# Output the tests for visual testing in the wiki.
+#
+sub output_tests {
+
+    my $test = 1;
+
+    print "\n----\n\n";
+
+    for my $test_ref (@tests) {
+
+        my $parser  =  Pod::Simple::Wiki->new($style, $opts);
+        my $pod     =  $test_ref->[0];
+        my $name    =  $test_ref->[2];
+
+        $pod        =~ s/=pod\n\n//;
+        $pod        = "=pod\n\n=head1 Test ". $test++ . " $name\n\n$pod";
+
+        $parser->parse_string_document($pod);
+    }
+}
+
+
+__END__

--- a/t/05_08_mediawiki_sentence_case_headers.t
+++ b/t/05_08_mediawiki_sentence_case_headers.t
@@ -1,0 +1,90 @@
+#!/usr/bin/perl -w
+
+###############################################################################
+#
+# A test for Pod::Simple::Wiki.
+#
+# Tests for =head1 pod sentence-cased directives.
+#
+# reverse('©'), October 2012, Peter Hallam, pragmatic@cpan.org
+#
+
+
+use strict;
+
+use Pod::Simple::Wiki;
+use Test::More tests => 2;
+
+my $style = 'mediawiki';
+my $opts  = { sentence_case_headers => 1 };
+
+# Output the tests for visual testing in the wiki.
+# END{output_tests()};
+
+my @tests  = (
+                [ "=pod\n\n=head1 DESCRIPTION" => qq(==Description==\n)],
+                [ "=pod\n\n=head1 COPYRIGHT & LICENSE" => qq(==Copyright & license==\n)],
+             );
+
+
+
+
+###############################################################################
+#
+#  Run the tests.
+#
+for my $test_ref (@tests) {
+
+    my $parser  = Pod::Simple::Wiki->new($style, $opts);
+    my $pod     = $test_ref->[0];
+    my $target  = $test_ref->[1];
+    my $wiki;
+
+    $parser->output_string(\$wiki);
+    $parser->parse_string_document($pod);
+
+
+    is($wiki, $target, "\tTesting: " . encode_escapes($pod));
+}
+
+
+###############################################################################
+#
+# Encode escapes to make them visible in the test output.
+#
+sub encode_escapes {
+    my $data = $_[0];
+
+    for ($data) {
+        s/\t/\\t/g;
+        s/\n/\\n/g;
+    }
+
+    return $data;
+}
+
+
+###############################################################################
+#
+# Output the tests for visual testing in the wiki.
+#
+sub output_tests {
+
+    my $test = 1;
+
+    print "\n----\n\n";
+
+    for my $test_ref (@tests) {
+
+        my $parser  =  Pod::Simple::Wiki->new($style, $opts);
+        my $pod     =  $test_ref->[0];
+        my $pod2    =  encode_escapes($pod);
+           $pod2    =~ s/^=pod\\n\\n//;
+
+        print "Test ", $test++, ":\t", $pod2, "\n";
+        $parser->parse_string_document($pod);
+        print "\n----\n\n";
+    }
+}
+
+__END__

--- a/t/05_09_mediawiki_remove_name_section.t
+++ b/t/05_09_mediawiki_remove_name_section.t
@@ -1,0 +1,79 @@
+#!/usr/bin/perl -w
+
+###############################################################################
+#
+# A test for Pod::Simple::Wiki.
+#
+# Tests for the removal of a NAME section.
+#
+# reverse('©'), October 2012, Peter Hallam, pragmatic@cpan.org
+#
+
+
+use strict;
+
+use Pod::Simple::Wiki;
+use Test::More tests => 1;
+
+my $style = 'mediawiki';
+my $opts  = { remove_name_section => 1 };
+
+# Output the tests for visual testing in the wiki.
+# END{output_tests()};
+
+my @tests  = (
+
+  # Links
+  [ qq(=pod\n\n=head1 NAME\n\nOther::Module - Other abstract\n\n=head1 DESCRIPTION\n\nSome description) => qq(Other abstract\n\n==DESCRIPTION==\nSome description\n\n),   'Other::Module'],
+  # [ qq(=pod\n\n=head1 Name\n\nOther::Module - Other abstract) => qq(Other abstract\n\n),   'Other::Module'],
+
+);
+
+
+
+###############################################################################
+#
+#  Run the tests.
+#
+for my $test_ref (@tests) {
+
+    my $parser  = Pod::Simple::Wiki->new($style, $opts);
+    my $pod     = $test_ref->[0];
+    my $target  = $test_ref->[1];
+    my $name    = $test_ref->[2];
+    my $wiki;
+
+    $parser->output_string(\$wiki);
+    $parser->parse_string_document($pod);
+
+    is($wiki, $target, "\tTesting: $name");
+}
+
+
+###############################################################################
+#
+# Output the tests for visual testing in the wiki.
+#
+sub output_tests {
+
+    my $test = 1;
+
+    print "\n----\n\n";
+
+    for my $test_ref (@tests) {
+
+        my $parser  =  Pod::Simple::Wiki->new($style, $opts);
+        my $pod     =  $test_ref->[0];
+        my $name    =  $test_ref->[2];
+
+        $pod        =~ s/=pod\n\n//;
+        $pod        = "=pod\n\n=head1 Test ". $test++ . " $name\n\n$pod";
+
+        $parser->parse_string_document($pod);
+
+        print $pod;
+    }
+}
+
+
+__END__


### PR DESCRIPTION
Hi John,

I have re-worked my modifications using the feedback you gave as guidance.  I  agreed with all your suggestions and points raised, and I have tried to incorporate them into this new pull request.  Now the default action if no options are passed is to produce exactly the same output as the previous commit by yourself.  Thanks for spending the time to go through it, it was useful reality check to be reminded that with my enthusiasm to get my modifications added quickly, I'd overlooked a few (critical) points.

A quick summary of the changes:
- Added an extra option `transformer_lists` to make my list modifications only when this option is enabled.
- Tried to make the option names more descriptive.
- Tests created for each individual new option.
- Documentation added for the options in the POD.
- Reverted the case changing of all module file names and references in the code and documentation back to their original state.

Further on the last point, I had originally started off by writing a new subclass of the Mediawiki module but was unhappy because of the naming restrictions.  I then later decided to make the output formatting changes to the existing module as this seemed a cleaner approach, but I left in those modifications, which of course in hindsight may have broken many people's installations.  I would perhaps suggest for a future update leaving the existing module names as-is, but removing the case changing function calls in Pod::Simple::Wiki::new(), so as to allow potential future sub-classes freedom in choosing their case, although at this stage I'm thinking I've probably dwelled too long on the aesthetics of the module names!

Regards,
Peter Hallam
