### PR TITLE
Fixes RT#38833 / Issue #4: escaping special symbols in text and headers

### DIFF
--- a/lib/Pod/Simple/Wiki/Confluence.pm
+++ b/lib/Pod/Simple/Wiki/Confluence.pm
@@ -99,16 +99,11 @@ sub _handle_text {
     my $self = shift;
     my $text = $_[0];
 
-    # Only escape words in paragraphs
-    if ( not $self->{_in_Para} ) {
-        $self->{_wiki_text} .= $text;
-        return;
-    }
-
     # Split the text into tokens but maintain the whitespace
     my @tokens = split /(\s+)/, $text;
 
     # Escape any tokens here, if necessary.
+    @tokens = map { s/([[{*_-])/\\$1/g; $_ } @tokens;
 
     # Rejoin the tokens and whitespace.
     $self->{_wiki_text} .= join '', @tokens;

--- a/t/confluence_head.t
+++ b/t/confluence_head.t
@@ -13,7 +13,7 @@
 use strict;
 
 use Pod::Simple::Wiki;
-use Test::More tests => 4;
+use Test::More tests => 5;
 
 my $style = 'confluence';
 
@@ -25,6 +25,10 @@ my @tests = (
     [ "=pod\n\n=head2 Head 2" => qq(h2. Head 2\n\n) ],
     [ "=pod\n\n=head3 Head 3" => qq(h3. Head 3\n\n) ],
     [ "=pod\n\n=head4 Head 4" => qq(h4. Head 4\n\n) ],
+    [
+        "=pod\n\n=head1 [head] {head} -head- _head_ *head*" =>
+          qq(h1. \\[head] \\{head} \\-head\\- \\_head\\_ \\*head\\*\n\n)
+    ],
 );
 
 


### PR DESCRIPTION
This fixes https://rt.cpan.org/Public/Bug/Display.html?id=38833 (references in #4) and adds a test.

Output checked on Confluence trial version server.