### PR TITLE
Add support for the dokuwiki format

### DIFF
--- a/bin/pod2wiki
+++ b/bin/pod2wiki
@@ -152,6 +152,10 @@ Emacs Muse (also known as "Muse" or "Emacs-Muse") is an authoring and publishing
 
 This is the format used by Confluence. See: L<http://www.atlassian.com/software/confluence/>.
 
+=item dokuwiki
+
+This is the format used by Dokuwiki. See: L<https://www.dokuwiki.org>.
+
 =back
 
 

--- a/lib/Pod/Simple/Wiki/Dokuwiki.pm
+++ b/lib/Pod/Simple/Wiki/Dokuwiki.pm
@@ -1,0 +1,216 @@
+package Pod::Simple::Wiki::Dokuwiki;
+
+###############################################################################
+#
+# Pod::Simple::Wiki::Dokuwiki - A class for creating Pod to Dokuwiki filters.
+#
+#
+# Copyright 2003-2008, John McNamara, jmcnamara@cpan.org
+# Copyright 2008 Joe Cooper, joe@virtualmin.com
+#
+# Documentation after __END__
+#
+
+use Pod::Simple::Wiki;
+use strict;
+use vars qw(@ISA $VERSION);
+
+
+@ISA     = qw(Pod::Simple::Wiki);
+$VERSION = '0.08';
+
+###############################################################################
+#
+# The tag to wiki mappings.
+#
+my $tags = {
+            '<b>'    => '**',
+            '</b>'   => '**',
+            '<i>'    => '//',
+            '</i>'   => '//',
+            '<tt>'   => "''",
+            '</tt>'  => "''",
+            '<pre>'  => "<code>\n",
+            '</pre>' => "\n</code>",
+
+            '<h1>'   => "====== ",
+            '</h1>'  => " ======\n",
+            '<h2>'   => "===== ",
+            '</h2>'  => " =====\n",
+            '<h3>'   => "==== ",
+            '</h3>'  => " ====\n",
+            '<h4>'   => "=== ",
+            '</h4>'  => " ===\n",
+           };
+
+###############################################################################
+#
+# new()
+#
+# Simple constructor inheriting from Pod::Simple::Wiki.
+#
+sub new {
+
+    my $class                   = shift;
+    my $self                    = Pod::Simple::Wiki->new('wiki', @_);
+       $self->{_tags}           = $tags;
+
+    bless  $self, $class;
+    return $self;
+}
+
+# Portme. How Pod "=over" blocks are converted to Template wiki lists.
+
+###############################################################################
+#
+# _indent_item()
+#
+# Indents an "over-item" to the correct level.
+#
+sub _indent_item {
+
+    my $self         = shift;
+    my $item_type    = $_[0];
+    my $item_param   = $_[1];
+    my $indent_level = $self->{_item_indent};
+
+    if    ($item_type eq 'bullet') {
+         $self->_append('  ' x $indent_level . '* ');
+    }
+    elsif ($item_type eq 'number') {
+         $self->_append('  ' x $indent_level . '- ');
+    }
+    elsif ($item_type eq 'text') {
+         # Dokuwiki has no "indent" without bullets or numbers, punt
+         $self->_append('  ' x $indent_level . '* **');
+    }
+}
+
+###############################################################################
+#
+# _handle_text()
+#
+# Perform any necessary transforms on the text. This is mainly used to escape
+# inadvertent CamelCase words.
+#
+sub _handle_text {
+
+    my $self = shift;
+    my $text = $_[0];
+
+    # Only escape words in paragraphs
+    if (not $self->{_in_Para}) {
+        $self->{_wiki_text} .= $text;
+        return;
+    }
+
+    # Split the text into tokens but maintain the whitespace
+    my @tokens = split /(\s+)/, $text;
+
+    # Escape any tokens here, if necessary.
+
+    # Rejoin the tokens and whitespace.
+    $self->{_wiki_text} .= join '', @tokens;
+}
+
+
+###############################################################################
+#
+# Functions to deal with =over ... =back regions for
+#
+# Bulleted lists
+# Numbered lists
+# Text     lists
+# Block    lists
+#
+sub _end_item_text     {$_[0]->_output('**: ')}
+
+
+# Portme: Probably won't have to change this.
+
+###############################################################################
+#
+# _start_Para()
+#
+# Special handling for paragraphs that are part of an "over" block.
+#
+sub _start_Para {
+
+    my $self         = shift;
+    my $indent_level = $self->{_item_indent};
+
+    if ($self->{_in_over_block}) {
+        # Do something here is necessary
+    }
+}
+
+1;
+
+
+__END__
+
+
+=head1 NAME
+
+Pod::Simple::Wiki::Dokuwiki - A class for creating Pod to Dokuwiki wiki filters.
+
+=head1 SYNOPSIS
+
+This module isn't used directly. Instead it is called via C<Pod::Simple::Wiki>:
+
+    #!/usr/bin/perl -w
+
+    use strict;
+    use Pod::Simple::Wiki;
+
+
+    my $parser = Pod::Simple::Wiki->new('dokuwiki');
+
+    ...
+
+
+Convert Pod to a Template wiki format using the installed C<pod2wiki> utility:
+
+    pod2wiki --style dokuwiki file.pod > file.wiki
+
+
+=head1 DESCRIPTION
+
+The C<Pod::Simple::Wiki::Dokuwiki> module is used for converting Pod text to Wiki text.
+
+Pod (Plain Old Documentation) is a simple markup language used for writing Perl documentation.
+
+For an introduction to Dokuwiki see: http://wiki.splitbrain.org/wiki:dokuwiki
+
+This module isn't generally invoked directly. Instead it is called via C<Pod::Simple::Wiki>. See the L<Pod::Simple::Wiki> and L<pod2wiki> documentation for more information.
+
+
+=head1 METHODS
+
+Pod::Simple::Wiki::Dokuwiki inherits all of the methods of C<Pod::Simple> and C<Pod::Simple::Wiki>. See L<Pod::Simple> and L<Pod::Simple::Wiki> for more details.
+
+=head1 Dokuwiki Specific information
+
+Dokuwiki does not support indentation outside of pre-formatted blocks, except for bulleted lists, so indentation is represented by an unordered list.
+
+=head1 SEE ALSO
+
+This module also installs a C<pod2wiki> command line utility. See C<pod2wiki --help> for details.
+
+
+=head1 DISCLAIMER OF WARRANTY
+
+Please refer to the DISCLAIMER OF WARRANTY in L<Pod::Simple::Wiki>.
+
+
+=head1 AUTHORS
+
+John McNamara jmcnamara@cpan.org
+
+Joe Cooper joe@virtualmin.com
+
+=head1 COPYRIGHT
+
+© MMIII-MMVIII, John McNamara.
+
+All Rights Reserved. This module is free software. It may be used, redistributed and/or modified under the same terms as Perl itself.

--- a/t/dokuwiki_format.t
+++ b/t/dokuwiki_format.t
@@ -1,0 +1,80 @@
+#!/usr/bin/perl -w
+
+###############################################################################
+#
+# A test for Pod::Simple::Wiki.
+#
+# Tests for I<>, B<>, C<> etc., formatting codes.
+#
+# Copyright (c), August 2004, John McNamara, jmcnamara@cpan.org
+#
+
+
+use strict;
+
+use Pod::Simple::Wiki;
+use Test::More tests => 6;
+
+my $style = 'dokuwiki';
+
+# Output the tests for visual testing in the wiki.
+# END{output_tests()};
+
+my @tests = (
+    # Simple formatting tests
+    [ "=pod\n\nI<Foo>" => qq(//Foo//\n\n),  'Italic' ],
+    [ "=pod\n\nB<Foo>" => qq(**Foo**\n\n),  'Bold' ],
+    [ "=pod\n\nC<Foo>" => qq(''Foo''\n\n),  'Monospace' ],
+    [ "=pod\n\nF<Foo>" => qq(//Foo//\n\n),  'Filename' ],
+
+    # Nested formatting tests
+    [ "=pod\n\nB<I<Foo>>" => qq(**//Foo//**\n\n), 'Bold Italic' ],
+    [ "=pod\n\nI<B<Foo>>" => qq(//**Foo**//\n\n), 'Italic Bold' ],
+);
+
+
+###############################################################################
+#
+#  Run the tests.
+#
+for my $test_ref ( @tests ) {
+
+    my $parser = Pod::Simple::Wiki->new( $style );
+    my $pod    = $test_ref->[0];
+    my $target = $test_ref->[1];
+    my $name   = $test_ref->[2];
+    my $wiki;
+
+    $parser->output_string( \$wiki );
+    $parser->parse_string_document( $pod );
+
+    is( $wiki, $target, "\tTesting: $name" );
+}
+
+
+###############################################################################
+#
+# Output the tests for visual testing in the wiki.
+#
+sub output_tests {
+
+    my $test = 1;
+
+    print "\n\n";
+
+    for my $test_ref ( @tests ) {
+
+        my $parser = Pod::Simple::Wiki->new( $style );
+        my $pod    = $test_ref->[0];
+        my $name   = $test_ref->[2];
+
+        $pod =~ s/=pod\n\n//;
+        $pod = "=pod\n\n=head2 Test " . $test++ . " $name\n\n$pod";
+
+        $parser->parse_string_document( $pod );
+    }
+}
+
+
+__END__
+

--- a/t/dokuwiki_head.t
+++ b/t/dokuwiki_head.t
@@ -1,0 +1,92 @@
+#!/usr/bin/perl -w
+
+###############################################################################
+#
+# A test for Pod::Simple::Wiki.
+#
+# Tests for =head pod directives.
+#
+# Copyright (c), August 2004, John McNamara, jmcnamara@cpan.org
+#
+
+
+use strict;
+
+use Pod::Simple::Wiki;
+use Test::More tests => 4;
+
+my $style = 'dokuwiki';
+
+# Output the tests for visual testing in the wiki.
+# END{output_tests()};
+
+my @tests = (
+    [ "=pod\n\n=head1 Head 1" => qq(====== Head 1 ======\n)],
+    [ "=pod\n\n=head2 Head 2" => qq(===== Head 2 =====\n)],
+    [ "=pod\n\n=head3 Head 3" => qq(==== Head 3 ====\n)],
+    [ "=pod\n\n=head4 Head 4" => qq(=== Head 4 ===\n)],
+);
+
+
+###############################################################################
+#
+#  Run the tests.
+#
+for my $test_ref ( @tests ) {
+
+    my $parser = Pod::Simple::Wiki->new( $style );
+    my $pod    = $test_ref->[0];
+    my $target = $test_ref->[1];
+    my $wiki;
+
+    $parser->output_string( \$wiki );
+    $parser->parse_string_document( $pod );
+
+
+    is( $wiki, $target, "\tTesting: " . encode_escapes( $pod ) );
+}
+
+
+###############################################################################
+#
+# Encode escapes to make them visible in the test output.
+#
+sub encode_escapes {
+    my $data = $_[0];
+
+    for ( $data ) {
+        s/\t/\\t/g;
+        s/\n/\\n/g;
+    }
+
+    return $data;
+}
+
+
+###############################################################################
+#
+# Output the tests for visual testing in the wiki.
+#
+sub output_tests {
+
+    my $test = 1;
+
+    print "\n----\n\n";
+
+    for my $test_ref ( @tests ) {
+
+        my $parser = Pod::Simple::Wiki->new( $style );
+        my $pod    = $test_ref->[0];
+        my $pod2   = encode_escapes( $pod );
+        $pod2 =~ s/^=pod\\n\\n//;
+
+        print "Test ", $test++, ":\t", $pod2, "\n";
+        $parser->parse_string_document( $pod );
+        print "\n----\n\n";
+    }
+}
+
+__END__
+
+
+

--- a/t/dokuwiki_lists.t
+++ b/t/dokuwiki_lists.t
@@ -1,0 +1,580 @@
+#!/usr/bin/perl -w
+
+###############################################################################
+#
+# A test for Pod::Simple::Wiki.
+#
+# Tests for =over ... =back regions.
+#
+# Copyright (c), August 2004, John McNamara, jmcnamara@cpan.org
+#
+
+
+use strict;
+
+use Pod::Simple::Wiki;
+use Test::More tests => 13;
+
+my $style = 'dokuwiki';
+
+# Output the tests for visual testing in the wiki.
+# END{output_tests()};
+
+my @tests;
+
+#
+# Extract tests embedded in _DATA_ section.
+#
+my $test_no = 1;
+my $pod;
+my $test = '';
+my $todo = '';
+my $name;
+
+while ( <DATA> ) {
+    if ( /^#/ ) {
+        $name = $1 if /NAME: (.*)/;
+        $todo = $1 if /TODO: (.*)/;
+
+        if ( $test ) {
+            if ( $test_no % 2 ) {
+                $pod = $test;
+            }
+            else {
+                push @tests, [ $pod, $test, $name, $todo ];
+                $name = '';
+                $todo = '';
+            }
+
+            $test = '';
+            $test_no++;
+        }
+        next;
+    }
+    s/\r//;        # Remove any \r chars that slip in.
+    s/\\t/\t/g;    # Sub back in any escaped tabs.
+    s/\\s/ /g;     # Sub back in any escaped spaces.
+    s/\\#/#/g;     # Sub back in any escaped comments.
+    $test .= $_;
+}
+
+
+###############################################################################
+#
+#  Run the tests.
+#
+for my $test_ref ( @tests ) {
+
+    my $parser = Pod::Simple::Wiki->new( $style );
+    my $pod    = $test_ref->[0];
+    my $target = $test_ref->[1];
+    my $name   = $test_ref->[2];
+    my $todo   = $test_ref->[3];
+    my $wiki;
+
+    $parser->output_string( \$wiki );
+    $parser->parse_string_document( $pod );
+
+    local $TODO = $todo;
+    is( $wiki, $target, " \t" . $name );
+}
+
+
+###############################################################################
+#
+# Output the tests for visual testing in the wiki.
+#
+sub output_tests {
+
+    my $test = 1;
+
+    print "\n----\n\n";
+
+    for my $test_ref (@tests) {
+
+        my $parser  =  Pod::Simple::Wiki->new($style);
+        my $pod     =  $test_ref->[0];
+        my $name    =  $test_ref->[2];
+
+        print "=== Test ", $test++, ":\t", $name, " ===\n\n";
+        $parser->parse_string_document($pod);
+        print "\n====\n\n";
+    }
+}
+
+__DATA__
+################################################################################
+#
+# Test data.
+#
+################################################################################
+#
+# NAME: Test for single unordered (bullet) item.
+#
+=pod
+
+=over
+
+=item *
+
+Bullet item
+
+=back
+
+=cut
+#
+#
+# Expected output.
+#
+#
+  * Bullet item
+
+################################################################################
+#
+# NAME: Test for unordered (bullet) list, <ul>.
+#
+=pod
+
+=over
+
+=item *
+
+Bullet item 1.0
+
+=item *
+
+Bullet item 2.0
+
+=item *
+
+Bullet item 3.0
+
+=back
+
+=cut
+#
+#
+# Expected output.
+#
+#
+  * Bullet item 1.0
+  * Bullet item 2.0
+  * Bullet item 3.0
+
+###############################################################################
+#
+# NAME: Test for nested unordered (bullet) list, <ul>.
+#
+=pod
+
+=over
+
+=item *
+
+Bullet item 1.0
+
+=over
+
+=item *
+
+Bullet item 1.1
+
+=over
+
+=item *
+
+Bullet item 1.2
+
+=item *
+
+Bullet item 2.2
+
+=back
+
+
+=item *
+
+Bullet item 2.1
+
+=back
+
+=item *
+
+Bullet item 2.0
+
+=back
+
+=cut
+#
+#
+# Expected output.
+#
+#
+  * Bullet item 1.0
+    * Bullet item 1.1
+      * Bullet item 1.2
+      * Bullet item 2.2
+    * Bullet item 2.1
+  * Bullet item 2.0
+
+################################################################################
+#
+# NAME: Test for single ordered (number) item.
+#
+=pod
+
+=over
+
+=item 1
+
+Number item
+
+=back
+
+=cut
+#
+#
+# Expected output.
+#
+#
+  - Number item
+
+###############################################################################
+#
+# NAME: Test for ordered (number) list, <ol>.
+#
+=pod
+
+=over
+
+=item 1
+
+Number item 1.0
+
+=item 2
+
+Number item 2.0
+
+=item 3
+
+Number item 3.0
+
+=back
+
+=cut
+#
+#
+# Expected output.
+#
+#
+  - Number item 1.0
+  - Number item 2.0
+  - Number item 3.0
+
+###############################################################################
+#
+# NAME: Test for nested ordered (number) list, <ol>.
+#
+=pod
+
+=over
+
+=item 1
+
+Number item 1.0
+
+=over
+
+=item 1
+
+Number item 1.1
+
+=over
+
+=item 1
+
+Number item 1.2
+
+=item 2
+
+Number item 2.2
+
+=back
+
+=item 2
+
+Number item 2.1
+
+=back
+
+=item 2
+
+Number item 2.0
+
+=back
+
+=cut
+#
+#
+# Expected output.
+#
+#
+  - Number item 1.0
+    - Number item 1.1
+      - Number item 1.2
+      - Number item 2.2
+    - Number item 2.1
+  - Number item 2.0
+
+################################################################################
+#
+# NAME: Test for single definition list item.
+#
+=pod
+
+=over
+
+=item Foo
+
+Definition item
+
+=back
+
+=cut
+#
+#
+# Expected output.
+#
+#
+  * **Foo**: Definition item
+
+###############################################################################
+#
+# NAME: Test for definition list, <dl>.
+#
+=pod
+
+=over
+
+=item Foo
+
+Definition item 1.0
+
+=item Bar
+
+Definition item 2.0
+
+=item Baz
+
+Definition item 3.0
+
+=back
+
+=cut
+#
+#
+# Expected output.
+#
+#
+  * **Foo**: Definition item 1.0
+  * **Bar**: Definition item 2.0
+  * **Baz**: Definition item 3.0
+
+###############################################################################
+#
+# NAME: Test for nested definition list, <dl>.
+#
+=pod
+
+=over
+
+=item Foo
+
+Definition item 1.0
+
+=over
+
+=item Foo
+
+Definition item 1.1
+
+=over
+
+=item Foo
+
+Definition item 1.2
+
+=item Bar
+
+Definition item 2.2
+
+=back
+
+=item Bar
+
+Definition item 2.1
+
+=back
+
+=item Bar
+
+Definition item 2.0
+
+=back
+
+=cut
+#
+#
+# Expected output.
+#
+#
+  * **Foo**: Definition item 1.0
+    * **Foo**: Definition item 1.1
+      * **Foo**: Definition item 1.2
+      * **Bar**: Definition item 2.2
+    * **Bar**: Definition item 2.1
+  * **Bar**: Definition item 2.0
+
+###############################################################################
+#
+# NAME: Test for varied nested list.
+#
+=pod
+
+=over
+
+=item *
+
+Bullet item 1.0
+
+=over
+
+=item 1
+
+Number item 1.1
+
+=over
+
+=item Foo
+
+Definition item 1.2
+
+=item Bar
+
+Definition item 2.2
+
+=back
+
+=item 2
+
+Number item 2.1
+
+=back
+
+=item *
+
+Bullet item 2.0
+
+=back
+
+=cut
+#
+#
+# Expected output.
+#
+#
+  * Bullet item 1.0
+    - Number item 1.1
+      * **Foo**: Definition item 1.2
+      * **Bar**: Definition item 2.2
+    - Number item 2.1
+  * Bullet item 2.0
+
+################################################################################
+#
+# NAME: Test for definition list without =items, <blockquote>.
+#
+=pod
+
+=over
+
+This is a long sentence that forms part of a definition block.
+
+=back
+
+=cut
+#
+#
+# Expected output.
+#
+#
+This is a long sentence that forms part of a definition block.
+
+################################################################################
+#
+# NAME: Test for unordered list with included paragraphs.
+#
+# TODO: Fix this later.
+#
+#
+=pod
+
+=over
+
+=item *
+
+This is the main item.
+
+This is a follow-on paragraph.
+
+And this is another.
+
+=back
+
+=cut
+#
+#
+# Expected output.
+#
+#
+  * This is the main item.
+    This is a follow-on paragraph.
+    And this is another.
+
+################################################################################
+#
+# NAME: Test for numbered list with included paragraphs.
+#
+#
+# TODO: Fix this later.
+#
+#
+=pod
+
+=over
+
+=item 1.
+
+This is the main item.
+
+This is a follow-on paragraph.
+
+And this is another.
+
+=back
+
+=cut
+#
+#
+# Expected output.
+#
+#
+ 1. This is the main item.
+    This is a follow-on paragraph.
+    And this is another.
+
+###############################################################################
+#
+# End
+#
+###############################################################################


### PR DESCRIPTION
This is effectively the patch attached to the following old ticket:

https://rt.cpan.org/Public/Bug/Display.html?id=36859

The rest is an entry in pod2wiki, style-adjustments and the removal of a
stray semi-colon.

The copyright claims in the submitted files probably don't make much sense.